### PR TITLE
Disable default features for image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 log = "0.4.16"
 rand = "0.8.5"
-image = "0.24.5"
+image = { version = "0.24.5", default-features = false, features = ["jpeg"] }
 base64 = "0.21.0"
 imageproc= "0.23.0"
 rusttype = "0.9.2"


### PR DESCRIPTION
Since this crate is only generating jpeg, disabling the default features of the image crate and enabling only the 'jpeg' feature removes 40 transitive 
dependencies:

```
adler 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)
bit_field 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)
bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)
bumpalo 3.13.0 (registry+https://github.com/rust-lang/crates.io-index)
crc32fast 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)
crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)
exr 1.6.3 (registry+https://github.com/rust-lang/crates.io-index)
fdeflate 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)
flate2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)
flume 0.10.14 (registry+https://github.com/rust-lang/crates.io-index)
futures-core 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)
futures-sink 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)
gif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)
half 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)
js-sys 0.3.63 (registry+https://github.com/rust-lang/crates.io-index)
lebe 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)
lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)
miniz_oxide 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)
miniz_oxide 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)
nanorand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)
once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)
pin-project 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)
pin-project-internal 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)
png 0.17.8 (registry+https://github.com/rust-lang/crates.io-index)
proc-macro2 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)
qoi 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)
quote 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)
simd-adler32 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)
smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)
spin 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)
syn 2.0.17 (registry+https://github.com/rust-lang/crates.io-index)
tiff 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)
unicode-ident 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)
wasm-bindgen 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)
wasm-bindgen-backend 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)
wasm-bindgen-macro 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)
wasm-bindgen-macro-support 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)
wasm-bindgen-shared 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)
weezl 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)
zune-inflate 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)
```
