### PR TITLE
🧹 Simplify random float generation in get_next

### DIFF
--- a/src/captcha/standard.rs
+++ b/src/captcha/standard.rs
@@ -61,7 +61,8 @@ pub fn get_next(min: f32, max: u32) -> f32 {
     if (max as f32) <= min {
         return min;
     }
-    min + get_rnd(max as usize - min as usize) as f32
+    let mut rng = rng();
+    rng.random_range(min..=(max as f32))
 }
 
 // ==========================================


### PR DESCRIPTION
🎯 **What:** Simplified the `get_next` function in `src/captcha/standard.rs:60` to directly generate a random float using `rand::rng().random_range()`.
💡 **Why:** The previous implementation manually generated a discrete random integer, cast it to `f32`, and added it to `min`. Using `rand` directly is simpler, more idiomatic, faster, and correctly outputs a continuous random float (avoiding integer snapping for more natural coordinate variations).
✅ **Verification:** Verified via `cargo check` and `cargo test`. All tests passed successfully without regressions.
✨ **Result:** Improved code readability and robustness by leveraging idiomatic standard features in the `rand` crate.

---
*PR created automatically by Jules for task [12532881520675402577](https://jules.google.com/task/12532881520675402577) started by @samirdjelal*